### PR TITLE
Update version to 2.7.5 and refactor software version handling in ClimateController.

### DIFF
--- a/rehau-nea-smart-mqtt-bridge/package-lock.json
+++ b/rehau-nea-smart-mqtt-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehau-nea-smart-mqtt-bridge-typescript",
-  "version": "2.7.3",
+  "version": "2.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehau-nea-smart-mqtt-bridge-typescript",
-      "version": "2.7.3",
+      "version": "2.7.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -210,7 +210,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.24.tgz",
       "integrity": "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2258,7 +2257,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/rehau-nea-smart-mqtt-bridge/package.json
+++ b/rehau-nea-smart-mqtt-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rehau-nea-smart-mqtt-bridge-typescript",
-  "version": "2.7.3",
+  "version": "2.7.5",
   "description": "MQTT bridge for REHAU NEA SMART 2.0 heating systems (TypeScript)",
   "main": "dist/index.js",
   "scripts": {

--- a/rehau-nea-smart-mqtt-bridge/src/climate-controller.ts
+++ b/rehau-nea-smart-mqtt-bridge/src/climate-controller.ts
@@ -12,6 +12,7 @@ import {
   QueuedCommand
 } from './types';
 import type { IInstall, IChannel, IZone, IGroup } from './parsers';
+import packageJson from '../package.json';
 
 interface ExtendedZoneInfo {
   zoneId: string;
@@ -30,6 +31,9 @@ const USE_GROUP_IN_NAMES = process.env.USE_GROUP_IN_NAMES === 'true';
 const COMMAND_RETRY_TIMEOUT = parseInt(process.env.COMMAND_RETRY_TIMEOUT || '30') * 1000; // Default 30 seconds
 const COMMAND_MAX_RETRIES = parseInt(process.env.COMMAND_MAX_RETRIES || '3'); // Default 3 retries
 const COMMAND_CHECK_INTERVAL = 5000; // Check pending commands every 5 seconds
+
+// Get version from package.json (single source of truth)
+const SW_VERSION = packageJson.version;
 
 class ClimateController {
   private mqttBridge: RehauMQTTBridge;
@@ -387,7 +391,7 @@ class ClimateController {
         name: `REHAU ${zone.installName}`,
         manufacturer: 'REHAU',
         model: 'NEA SMART 2.0',
-        sw_version: '2.7.3'
+        sw_version: SW_VERSION
       },
       
       // Temperature
@@ -475,7 +479,7 @@ class ClimateController {
         name: `REHAU ${installName}`,
         manufacturer: 'REHAU',
         model: 'NEA SMART 2.0',
-        sw_version: '2.7.3'
+        sw_version: SW_VERSION
       },
       state_topic: `homeassistant/sensor/rehau_${zoneId}_temperature/state`,
       device_class: 'temperature',
@@ -496,7 +500,7 @@ class ClimateController {
         name: `REHAU ${installName}`,
         manufacturer: 'REHAU',
         model: 'NEA SMART 2.0',
-        sw_version: '2.7.3'
+        sw_version: SW_VERSION
       },
       state_topic: `homeassistant/sensor/rehau_${zoneId}_humidity/state`,
       device_class: 'humidity',
@@ -531,7 +535,7 @@ class ClimateController {
         name: `REHAU ${installName}`,
         manufacturer: 'REHAU',
         model: 'NEA SMART 2.0',
-        sw_version: '2.7.3'
+        sw_version: SW_VERSION
       },
       state_topic: `homeassistant/binary_sensor/rehau_${zoneId}_demanding/state`,
       device_class: 'heat',
@@ -552,7 +556,7 @@ class ClimateController {
         name: `REHAU ${installName}`,
         manufacturer: 'REHAU',
         model: 'NEA SMART 2.0',
-        sw_version: '2.7.3'
+        sw_version: SW_VERSION
       },
       state_topic: `homeassistant/sensor/rehau_${zoneId}_demanding_percent/state`,
       unit_of_measurement: '%',
@@ -573,7 +577,7 @@ class ClimateController {
         name: `REHAU ${installName}`,
         manufacturer: 'REHAU',
         model: 'NEA SMART 2.0',
-        sw_version: '2.7.3'
+        sw_version: SW_VERSION
       },
       state_topic: `homeassistant/sensor/rehau_${zoneId}_dewpoint/state`,
       device_class: 'temperature',
@@ -677,7 +681,7 @@ class ClimateController {
         name: `REHAU ${installName}`,
         manufacturer: 'REHAU',
         model: 'NEA SMART 2.0',
-        sw_version: '2.7.3'
+        sw_version: SW_VERSION
       },
       state_topic: `homeassistant/lock/rehau_${zoneId}_lock/state`,
       command_topic: `homeassistant/lock/rehau_${zoneId}_lock/command`,
@@ -701,7 +705,7 @@ class ClimateController {
         name: `REHAU ${installName}`,
         manufacturer: 'REHAU',
         model: 'NEA SMART 2.0',
-        sw_version: '2.7.3'
+        sw_version: SW_VERSION
       },
       state_topic: `homeassistant/light/rehau_${zoneId}_ring_light/state`,
       command_topic: `homeassistant/light/rehau_${zoneId}_ring_light/command`,
@@ -778,7 +782,7 @@ class ClimateController {
         name: `REHAU ${installName}`,
         manufacturer: 'REHAU',
         model: 'NEA SMART 2.0',
-        sw_version: '2.7.3'
+        sw_version: SW_VERSION
       },
       state_topic: `homeassistant/sensor/rehau_${installId}_outside_temp/state`,
       device_class: 'temperature',
@@ -825,7 +829,7 @@ class ClimateController {
         name: `REHAU ${installName}`,
         manufacturer: 'REHAU',
         model: 'NEA SMART 2.0',
-        sw_version: '2.7.3'
+        sw_version: SW_VERSION
       },
       
       // Mode control only (heat/cool)


### PR DESCRIPTION
# Unify version management across the project

## Problem

Version numbers were scattered across multiple files with inconsistent values:
- `CHANGELOG.md`: 2.7.5 (latest version)
- `package.json`: 2.7.3
- `package-lock.json`: 2.7.3 (derived from package.json)
- `climate-controller.ts`: 2.7.3 hardcoded in 10 places
- `config.yaml`: 2.7.5

This made it easy to forget updating the version in some files when releasing a new version, leading to inconsistencies.

## Solution

Unified version management by using `package.json` as the single source of truth:
- The TypeScript code now dynamically reads the version from `package.json` at runtime
- All hardcoded version strings have been replaced with a constant that reads from `package.json`
- Updated `package.json` version to 2.7.5 to match the latest CHANGELOG entry

## Changes

### 1. Dynamic version reading in `climate-controller.ts`
- Added `import packageJson from '../package.json'`
- Created `SW_VERSION` constant that reads `packageJson.version`
- Replaced all 10 hardcoded `'2.7.3'` strings with `SW_VERSION`

### 2. Version synchronization
- Updated `package.json` version from `2.7.3` to `2.7.5`
- Updated `package-lock.json` via `npm install`

## Benefits

- **Single source of truth**: `package.json` is now the only place where the version needs to be updated
- **No more hardcoding**: The code automatically uses the version from `package.json`
- **Automatic synchronization**: When updating the version in `package.json`, the code immediately uses the new version
- **Reduced errors**: Impossible to forget updating the version in the code since it's read dynamically
- **Easier maintenance**: Future version updates only require changing `package.json`

## Technical Details

- TypeScript configuration already had `resolveJsonModule: true` enabled, so no config changes were needed
- The import works seamlessly with the existing build process
- All 10 occurrences of `sw_version` in device configurations now use the dynamic version

## Testing

- ✅ Project compiles successfully with `npm run build`
- ✅ No linter errors
- ✅ All version references verified to use the dynamic constant

## Notes

- `config.yaml` remains manual (as expected for Home Assistant addon configuration files)
- The version in `config.yaml` should still be updated manually when releasing new versions, but it's now clear that `package.json` is the primary source

