### PR TITLE
fix: Ensure REHAU MQTT reconnection works continuously

### DIFF
--- a/rehau-nea-smart-mqtt-bridge/src/mqtt-bridge.ts
+++ b/rehau-nea-smart-mqtt-bridge/src/mqtt-bridge.ts
@@ -212,9 +212,7 @@ class RehauMQTTBridge {
           });
         }
         
-        if (!isReconnect) {
-          resolve();
-        }
+        resolve();
       };
       
       this.haClient.on('connect', handleHAConnect);


### PR DESCRIPTION
Fixes #6 

Issues fixed:
- `isReconnecting` flag was shared between HA and REHAU connections, but both states are separate and conflating them can lead to issues (**not directly related to the REHAU reconnection issue, as HA doesn't tend to require reconnecting**
- Ensure MQTT connection handlers resolve even in reconnection scenarios, as the reset of the `isReconnecting` flags happens after that resolution